### PR TITLE
Update Queues docs - add ping for kafka

### DIFF
--- a/docs/en/queues/kafka.md
+++ b/docs/en/queues/kafka.md
@@ -28,6 +28,12 @@ kafka:
   # Required to use Kafka driver
   brokers: [ "127.0.0.1:9092", "127.0.0.1:9002" ]
 
+  # Ping to test connection to Kafka
+  #
+  # Optional, default: empty
+  ping:
+    timeout: "5s"
+
   # SASL authentication options to use for all connections. Depending on the auth type, plain or aws_msk_plain sections might be removed.
   #
   # Optional, default: empty


### PR DESCRIPTION
From https://github.com/roadrunner-server/kafka/pull/199

* Added **ping.timeout** option for kafka jobs driver